### PR TITLE
feat: add AGPL-3.0-only and AGPL-3.0-or-later license templates

### DIFF
--- a/util/tmpl.go
+++ b/util/tmpl.go
@@ -135,5 +135,34 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License 
 along with this program. If not, see <https://www.gnu.org/licenses/>.`
 
+const tmplAGPLThreeOrLater = `Copyright (C) {{ .Year }} {{ .Holder }}
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.`
+
+const tmplAGPLThreeOnly = `Copyright (C) {{ .Year }} {{ .Holder }}
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.`
+
 const tmplSPDXIDs = `{{ if .Holder }}Copyright{{ if .Year }} {{ .Year }}{{ end }} {{ .Holder }}
 {{ end }}SPDX-License-Identifier: {{ .SPDXIDs }}`

--- a/util/tmpl.go
+++ b/util/tmpl.go
@@ -49,6 +49,10 @@ func MatchTmpl(license string, useSPDXIDs bool) (string, error) {
 		return tmplGPLThreeOrLater, nil
 	case "gpl-3.0-only":
 		return tmplGPLThreeOnly, nil
+	case "agpl-3.0-or-later":
+		return tmplAGPLThreeOrLater, nil
+	case "agpl-3.0-only":
+		return tmplAGPLThreeOnly, nil
 	default:
 		return "", errLicenseNotSupported
 	}


### PR DESCRIPTION
#### What type of PR is this?

feat: A new feature

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.

#### More detail description for this PR.

Like #1 but for [GNU Affero General Public License](https://www.gnu.org/licenses/agpl-3.0.en.html)

~~Unlike #1, l've chosen to use caps for the license options (eg. `AGPL-3.0-only`) to exactly match [the SPDX identifier](https://spdx.org/licenses/) but I can't change this to match the other options (eg. `agpl-3.0-only`).~~ <= fixed as requested
