### PR TITLE
optimize: use multiline comments for PHP files

### DIFF
--- a/util/header.go
+++ b/util/header.go
@@ -63,9 +63,9 @@ func generateHeader(path string, tmpl []byte) []byte {
 		return h
 	}
 	switch ext {
-	case ".c", ".h", ".gv", ".java", ".scala", ".kt", ".kts":
+	case ".c", ".h", ".gv", ".java", ".scala", ".kt", ".kts", ".php":
 		header = doGenerate(tmpl, "/*", " * ", " */")
-		put(header, []string{".c", ".h", ".gv", ".java", ".scala", ".kt", ".kts"})
+		put(header, []string{".c", ".h", ".gv", ".java", ".scala", ".kt", ".kts", ".php"})
 	case ".js", ".mjs", ".cjs", ".jsx", ".tsx", ".css", ".scss", ".sass", ".ts":
 		header = doGenerate(tmpl, "/**", " * ", " */")
 		put(header, []string{".js", ".mjs", ".cjs", ".jsx", ".tsx", ".css", ".scss", ".sass", ".ts"})
@@ -87,9 +87,6 @@ func generateHeader(path string, tmpl []byte) []byte {
 	case ".html", ".xml", ".vue", ".wxi", ".wxl", ".wxs":
 		header = doGenerate(tmpl, "<!--", " ", "-->")
 		put(header, []string{".html", ".xml", ".vue", ".wxi", ".wxl", ".wxs"})
-	case ".php":
-		header = doGenerate(tmpl, "", "// ", "")
-		put(header, []string{".php"})
 	case ".j2":
 		header = doGenerate(tmpl, "{#", "", "#}")
 		put(header, []string{".j2"})


### PR DESCRIPTION
#### What type of PR is this?

optimize: A new optimization

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.

#### (Optional) More detail description for this PR.

I'd like to propose to use multiline comments for license headers in PHP files

```php
/*
 * …
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU Affero General Public License as published
 * by the Free Software Foundation, version 3.
 * …
 */
```

instead of single line comments

```php
// …
// This program is free software: you can redistribute it and/or modify
// it under the terms of the GNU Affero General Public License as published
// by the Free Software Foundation, version 3.
// …
```

This a more common practice as can be seen in Symfony, one of the mostly used PHP frameworks:
https://github.com/symfony/http-foundation/blob/3d7bbf071b25f802f7d55524d408bed414ea71e2/Response.php#L1-12