### PR TITLE
feat: add support for .twig files

### DIFF
--- a/util/header.go
+++ b/util/header.go
@@ -87,9 +87,9 @@ func generateHeader(path string, tmpl []byte) []byte {
 	case ".html", ".xml", ".vue", ".wxi", ".wxl", ".wxs":
 		header = doGenerate(tmpl, "<!--", " ", "-->")
 		put(header, []string{".html", ".xml", ".vue", ".wxi", ".wxl", ".wxs"})
-	case ".j2":
+	case ".j2", ".twig":
 		header = doGenerate(tmpl, "{#", "", "#}")
-		put(header, []string{".j2"})
+		put(header, []string{".j2", ".twig"})
 	case ".ml", ".mli", ".mll", ".mly":
 		header = doGenerate(tmpl, "(**", "   ", "*)")
 		put(header, []string{".ml", ".mli", ".mll", ".mly"})


### PR DESCRIPTION
#### What type of PR is this?

optimize: A new optimization

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.

#### More detail description for this PR.

Twig is a template engine & language used in the Symfony framework, among others. It uses `{#` and `#}` as delimiting characters for multiline comments.

Note : currently, when trying to add a header to a non supported format, nwa will do nothing but still displays a success message eg

```shell
2024/10/24 10:06:32 INFO file has been modified path=src/AppBundle/Resources/views/Article/show.html.twig
```

I think it would be better to display an error message stating that the format is unsupported, but that goes far beyond my very weak knowledge of Go.
