### PR TITLE
feat: Add support for .mk extension for makefiles

### DIFF
--- a/internal/header.go
+++ b/internal/header.go
@@ -74,9 +74,9 @@ func generateHeader(path string, tmpl []byte) ([]byte, error) {
 	case ".cc", ".cpp", ".cs", ".go", ".hcl", ".hh", ".hpp", ".m", ".mm", ".proto", ".rs", ".swift", ".dart", ".groovy", ".v", ".sv":
 		header = doGenerate(tmpl, "", "// ", "")
 		put(header, []string{".cc", ".cpp", ".cs", ".go", ".hcl", ".hh", ".hpp", ".m", ".mm", ".proto", ".rs", ".swift", ".dart", ".groovy", ".v", ".sv"})
-	case ".py", ".sh", ".yaml", ".yml", "makefile", ".dockerfile", "dockerfile", ".rb", "gemfile", ".tcl", ".tf", ".bzl", ".pl", ".pp", "build", ".build", ".toml":
+	case ".py", ".sh", ".yaml", ".yml", "makefile", ".mk", ".dockerfile", "dockerfile", ".rb", "gemfile", ".tcl", ".tf", ".bzl", ".pl", ".pp", "build", ".build", ".toml":
 		header = doGenerate(tmpl, "", "# ", "")
-		put(header, []string{".py", ".sh", ".yaml", ".yml", "makefile", ".dockerfile", "dockerfile", ".rb", "gemfile", ".tcl", ".tf", ".bzl", ".pl", ".pp", "build", ".build", ".toml"})
+		put(header, []string{".py", ".sh", ".yaml", ".yml", "makefile", ".mk", ".dockerfile", "dockerfile", ".rb", "gemfile", ".tcl", ".tf", ".bzl", ".pl", ".pp", "build", ".build", ".toml"})
 	case ".el", ".lisp":
 		header = doGenerate(tmpl, "", ";; ", "")
 		put(header, []string{".el", ".lisp"})


### PR DESCRIPTION
#### What type of PR is this?

feat: Add support for .mk extension for makefiles.  .mk is often used as an extension for [included
makefiles](https://www.gnu.org/software/make/manual/html_node/Include.html).
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) More detail description for this PR.

Test plan:
```
$ buildah build -t ghcr.io/b1nary-gr0up/nwa:main .
$ touch foo.mk
$ podman run --rm -v './:/src/' ghcr.io/b1nary-gr0up/nwa:main add -t LICENSE foo.mk
[NWA SUMMARY] scanned=1 modified=1 skipped=0 failed=0
```

#### Which issue(s) this PR fixes:

Fixes https://github.com/B1NARY-GR0UP/nwa/issues/16
Related https://github.com/B1NARY-GR0UP/nwa/pull/10