### PR TITLE
feat: Add support for Containerfile files

### DIFF
--- a/internal/header.go
+++ b/internal/header.go
@@ -74,9 +74,9 @@ func generateHeader(path string, tmpl []byte) ([]byte, error) {
 	case ".cc", ".cpp", ".cs", ".go", ".hcl", ".hh", ".hpp", ".m", ".mm", ".proto", ".rs", ".swift", ".dart", ".groovy", ".v", ".sv":
 		header = doGenerate(tmpl, "", "// ", "")
 		put(header, []string{".cc", ".cpp", ".cs", ".go", ".hcl", ".hh", ".hpp", ".m", ".mm", ".proto", ".rs", ".swift", ".dart", ".groovy", ".v", ".sv"})
-	case ".py", ".sh", ".yaml", ".yml", "makefile", ".mk", ".dockerfile", "dockerfile", ".rb", "gemfile", ".tcl", ".tf", ".bzl", ".pl", ".pp", "build", ".build", ".toml":
+	case ".py", ".sh", ".yaml", ".yml", "makefile", ".mk", "containerfile", ".dockerfile", "dockerfile", ".rb", "gemfile", ".tcl", ".tf", ".bzl", ".pl", ".pp", "build", ".build", ".toml":
 		header = doGenerate(tmpl, "", "# ", "")
-		put(header, []string{".py", ".sh", ".yaml", ".yml", "makefile", ".mk", ".dockerfile", "dockerfile", ".rb", "gemfile", ".tcl", ".tf", ".bzl", ".pl", ".pp", "build", ".build", ".toml"})
+		put(header, []string{".py", ".sh", ".yaml", ".yml", "makefile", ".mk", "containerfile", ".dockerfile", "dockerfile", ".rb", "gemfile", ".tcl", ".tf", ".bzl", ".pl", ".pp", "build", ".build", ".toml"})
 	case ".el", ".lisp":
 		header = doGenerate(tmpl, "", ";; ", "")
 		put(header, []string{".el", ".lisp"})


### PR DESCRIPTION
#### What type of PR is this?

feat: Add support for Containerfile files.  These are [very similar](https://github.com/containers/buildah/discussions/3170) to Dockerfile files that are already supported.  The different file name is popular with users of [podman](https://docs.podman.io/en/latest/markdown/podman-build.1.html) and buildah.

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) More detail description for this PR.

Test plan:
```
$ buildah build -t ghcr.io/b1nary-gr0up/nwa:main .
$ cp Dockerfile Containerfile
$ podman run --rm -v './:/src/' ghcr.io/b1nary-gr0up/nwa:main add -l apache -c 'BINARY Members' Containerfile
[NWA SUMMARY] scanned=1 modified=1 skipped=0 failed=0
$ podman run --rm -v './:/src/' ghcr.io/b1nary-gr0up/nwa:main check -l apache -c 'BINARY Members' Containerfile
[NWA SUMMARY] scanned=1 matched=1 mismatched=0 skipped=0 failed=0
$ head -n 3 Containerfile
# Copyright 2025 BINARY Members
#
# Licensed under the Apache License, Version 2.0 (the "License");
```

#### Which issue(s) this PR fixes:

Fixes https://github.com/B1NARY-GR0UP/nwa/issues/19