### PR TITLE
feat: Support command selection with the config command

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,10 @@ regardless of the previous license header.
 
 - **Flags**
 
-| Short | Long        | Default                            | Description     |
-|-------|-------------|------------------------------------|-----------------|
-| -h    | --help      | null                               | help for config |
+| Short | Long        | Default                            | Description        |
+|-------|-------------|------------------------------------|--------------------|
+| -c    | --command   | add                                | command to execute |
+| -h    | --help      | null                               | help for config    |
 
 **NOTE: If some configuration are not configured, the default configuration will be used.**
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -36,7 +36,7 @@ EXAMPLE: nwa config config.yaml -c check
 NOTE: This command only supports the command flag;
 You can only specify the path of the configuration file, and everything depends on the configuration file;
 If some configuration are not configured, the default configuration will be used;
-The command can be overwritten on the command line
+The command can be set on the command line
 SAMPLE CONFIGURATION FILE(YAML):
 nwa:
   cmd: "add"

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -32,10 +32,11 @@ var configCmd = &cobra.Command{
 	Use:   "config",
 	Short: "edit the files according to the configuration file",
 	Long: `Config Command | Edit files according to the configuration file
-EXAMPLE: nwa config config.yaml
-NOTE: This command does not have any flag;
+EXAMPLE: nwa config config.yaml -c check
+NOTE: This command only supports the command flag;
 You can only specify the path of the configuration file, and everything depends on the configuration file;
-If some configuration are not configured, the default configuration will be used
+If some configuration are not configured, the default configuration will be used;
+The command can be overwritten on the command line
 SAMPLE CONFIGURATION FILE(YAML):
 nwa:
   cmd: "add"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -132,6 +132,7 @@ func setupCommonCmd(common *cobra.Command) {
 }
 
 func setupConfigCmd(config *cobra.Command) {
+	config.Flags().StringVarP(&defaultConfig.Nwa.Cmd, "command", "c", defaultConfig.Nwa.Cmd, "command")
 	rootCmd.AddCommand(config)
 }
 


### PR DESCRIPTION
#### What type of PR is this?

feat: The `config` command is great for centralizing nwa configuration in a project.  It is weird though that the command being executed is part of the configuration.  My expectation for the `config` command would be to use pre-set paths, template, skip rules, etc. so one could run `add`/`update` manually and `check` in CI using the same configuration.  Since YAML doesn't support importing currently one has to copy/paste configuration files for each command being executed.

This change adds `-c` and `--command` switches to the `check` command that can overwrite the default command.  The priority order, low to high, is the default: `add`, the command line flag and what is configured in the config file with the highest priority.

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) More detail description for this PR.

Test plan:
```
$ buildah build -t ghcr.io/b1nary-gr0up/nwa:main .
$ cat <<EOF > .nwa-config.yml
nwa:
  path:
    - "**/*.go"
  license: apache
  holder: "BINARY Members"
  year: 2023
EOF
$ # command line command
$ podman run --rm -v './:/src/' ghcr.io/b1nary-gr0up/nwa:main config .nwa-config.yml -c check
2025/01/25 12:09:51 WARN file does not have a matched header path=internal/header.go
[NWA SUMMARY] scanned=11 matched=10 mismatched=1 skipped=0 failed=0
$ # default command
$ podman run --rm -v './:/src/' ghcr.io/b1nary-gr0up/nwa:main config .nwa-config.yml
2025/01/25 12:10:34 WARN file already has a header path=cmd/add.go
2025/01/25 12:10:34 WARN file already has a header path=cmd/check.go
2025/01/25 12:10:34 WARN file already has a header path=internal/task.go
2025/01/25 12:10:34 WARN file already has a header path=internal/operation.go
2025/01/25 12:10:34 WARN file already has a header path=internal/tmpl.go
2025/01/25 12:10:34 WARN file already has a header path=main.go
2025/01/25 12:10:34 WARN file already has a header path=cmd/remove.go
2025/01/25 12:10:34 WARN file already has a header path=cmd/config.go
2025/01/25 12:10:34 WARN file already has a header path=cmd/root.go
2025/01/25 12:10:34 WARN file already has a header path=cmd/update.go
2025/01/25 12:10:34 WARN file already has a header path=internal/header.go
[NWA SUMMARY] scanned=11 modified=0 skipped=0 failed=0
$ cat <<EOF > .nwa-config.yml
nwa:
  path:
    - "**/*.go"
  license: apache
  holder: "BINARY Members"
  year: 2023
  cmd: "check"
EOF
$ # config file command
$ podman run --rm -v './:/src/' ghcr.io/b1nary-gr0up/nwa:main config .nwa-config.yml
2025/01/25 12:12:21 WARN file does not have a matched header path=internal/header.go
[NWA SUMMARY] scanned=11 matched=10 mismatched=1 skipped=0 failed=0
```

#### Which issue(s) this PR fixes:

Fixes https://github.com/B1NARY-GR0UP/nwa/issues/21
