### PR TITLE
fix: Fix handling of files saved with UTF8 encoding with a byte-order mark #29

### DIFF
--- a/internal/header.go
+++ b/internal/header.go
@@ -219,6 +219,16 @@ func matchShebang(b []byte) []byte {
 }
 
 func assemble(shebang, header, content []byte, isUpdate bool) []byte {
+	// Check for UTF-8 BOM at the start of content
+	utf8BOM := []byte{0xEF, 0xBB, 0xBF}
+	hasBOM := len(content) >= 3 && bytes.Equal(content[:3], utf8BOM)
+	var body []byte
+
+	if hasBOM {
+		body = append(body, utf8BOM...)
+		content = content[3:]
+	}
+
 	if shebang != nil {
 		if !isUpdate {
 			// get content exclude the shebang
@@ -231,9 +241,11 @@ func assemble(shebang, header, content []byte, isUpdate bool) []byte {
 		}
 		header = append(shebang, header...)
 	}
-	// 1. shebang
-	// 2. header
-	// 3. content
-	header = append(header, content...)
-	return header
+	// 1. BOM (if present)
+	// 2. shebang
+	// 3. header
+	// 4. content
+	body = append(body, header...)
+	body = append(body, content...)
+	return body
 }

--- a/testdata/add/expected/file.withbom.cs
+++ b/testdata/add/expected/file.withbom.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2025 BINARY Members
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace HelloWorldApp {
+    class Program {
+        static void Main(string[] args) {
+            Console.WriteLine("Hello, World!");
+        }
+    }
+}

--- a/testdata/add/initial/file.withbom.cs
+++ b/testdata/add/initial/file.withbom.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace HelloWorldApp {
+    class Program {
+        static void Main(string[] args) {
+            Console.WriteLine("Hello, World!");
+        }
+    }
+}

--- a/testdata/check/file.withbom.cs
+++ b/testdata/check/file.withbom.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2025 BINARY Members
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace HelloWorldApp {
+    class Program {
+        static void Main(string[] args) {
+            Console.WriteLine("Hello, World!");
+        }
+    }
+}

--- a/testdata/remove/expected/file.withbom.cs
+++ b/testdata/remove/expected/file.withbom.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace HelloWorldApp {
+    class Program {
+        static void Main(string[] args) {
+            Console.WriteLine("Hello, World!");
+        }
+    }
+}

--- a/testdata/remove/initial/file.withbom.cs
+++ b/testdata/remove/initial/file.withbom.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2025 BINARY Members
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace HelloWorldApp {
+    class Program {
+        static void Main(string[] args) {
+            Console.WriteLine("Hello, World!");
+        }
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?

fix: Fix handling of files saved with UTF8 encoding with a byte-order mark #29

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) More detail description for this PR.

This PR changes the `assemble` function so that it first checks to see if the first three bytes of `content` match the utf8 BOM `0xEF, 0xBB, 0xBF`.

If the file `hasBOM`, then the output will be prefixed with those bytes, then the license header, then the original file content (all bytes that follow the first three bytes).

It also adds new test files for the `add`, `check`, and `remove` commands.

#### Which issue(s) this PR fixes:

Fixes #29 
